### PR TITLE
Feature/match clock approximation

### DIFF
--- a/match-service/src/main/java/ml/echelon133/matchservice/MatchServiceApplication.java
+++ b/match-service/src/main/java/ml/echelon133/matchservice/MatchServiceApplication.java
@@ -1,19 +1,20 @@
 package ml.echelon133.matchservice;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import ml.echelon133.common.constants.DateFormatConstants;
 import ml.echelon133.common.event.MatchEventDetailsMixIn;
 import ml.echelon133.common.event.dto.MatchEventDetails;
-import ml.echelon133.matchservice.event.model.dto.InsertMatchEventMixIn;
 import ml.echelon133.matchservice.event.model.dto.InsertMatchEvent;
+import ml.echelon133.matchservice.event.model.dto.InsertMatchEventMixIn;
 import ml.echelon133.matchservice.match.controller.validators.MatchCriteriaValidator;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import java.time.Clock;
 
 @SpringBootApplication
 @EnableDiscoveryClient
@@ -27,7 +28,6 @@ public class MatchServiceApplication {
 	@Bean
 	public static ObjectMapper objectMapper() {
 		var mapper = new ObjectMapper();
-		mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
 
 		// add information about serialization/deserialization of InsertMatchEvent's subclasses
 		mapper.addMixIn(InsertMatchEvent.class, InsertMatchEventMixIn.class);
@@ -44,5 +44,10 @@ public class MatchServiceApplication {
 	@Bean
 	public static MatchCriteriaValidator matchCriteriaValidator() {
 		return new MatchCriteriaValidator(DateFormatConstants.DATE_FORMAT);
+	}
+
+	@Bean
+	public static Clock clock() {
+		return Clock.systemUTC();
 	}
 }

--- a/match-service/src/main/java/ml/echelon133/matchservice/match/model/CompactMatchDto.java
+++ b/match-service/src/main/java/ml/echelon133/matchservice/match/model/CompactMatchDto.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 public interface CompactMatchDto {
     UUID getId();
     String getStatus();
+    LocalDateTime getStatusLastModifiedUTC();
     String getResult();
     UUID getCompetitionId();
     LocalDateTime getStartTimeUTC();
@@ -39,6 +40,7 @@ public interface CompactMatchDto {
     class CompactMatchDtoBuilder {
         private UUID id;
         private String status;
+        private LocalDateTime statusLastModifiedUTC;
         private String result;
         private UUID competitionId;
         private LocalDateTime startTimeUTC;
@@ -58,6 +60,11 @@ public interface CompactMatchDto {
 
         public CompactMatchDtoBuilder status(String status) {
             this.status = status;
+            return this;
+        }
+
+        public CompactMatchDtoBuilder statusLastModifiedUTC(LocalDateTime statusLastModifiedUTC) {
+            this.statusLastModifiedUTC = statusLastModifiedUTC;
             return this;
         }
 
@@ -116,6 +123,11 @@ public interface CompactMatchDto {
                 @Override
                 public String getStatus() {
                     return status;
+                }
+
+                @Override
+                public LocalDateTime getStatusLastModifiedUTC() {
+                    return statusLastModifiedUTC;
                 }
 
                 @Override

--- a/match-service/src/main/java/ml/echelon133/matchservice/match/model/Match.java
+++ b/match-service/src/main/java/ml/echelon133/matchservice/match/model/Match.java
@@ -26,6 +26,9 @@ public class Match extends BaseEntity {
     @Column(nullable = false, length = 15)
     private MatchStatus status;
 
+    @Column(name = "status_last_modified_utc")
+    private LocalDateTime statusLastModifiedUTC;
+
     @ManyToOne(optional = false, cascade = {CascadeType.MERGE, CascadeType.PERSIST})
     @JoinColumn(name = "home_team_id", nullable = false)
     private Team homeTeam;
@@ -83,6 +86,7 @@ public class Match extends BaseEntity {
 
     public Match() {
         this.status = MatchStatus.NOT_STARTED;
+        this.statusLastModifiedUTC = null;
         this.halfTimeScoreInfo = new ScoreInfo();
         this.scoreInfo = new ScoreInfo();
         this.penaltiesInfo = new ScoreInfo();
@@ -98,6 +102,14 @@ public class Match extends BaseEntity {
 
     public void setStatus(MatchStatus status) {
         this.status = status;
+    }
+
+    public LocalDateTime getStatusLastModifiedUTC() {
+        return statusLastModifiedUTC;
+    }
+
+    public void setStatusLastModifiedUTC(LocalDateTime statusLastModifiedUTC) {
+        this.statusLastModifiedUTC = statusLastModifiedUTC;
     }
 
     public Team getHomeTeam() {

--- a/match-service/src/main/java/ml/echelon133/matchservice/match/model/MatchDto.java
+++ b/match-service/src/main/java/ml/echelon133/matchservice/match/model/MatchDto.java
@@ -10,6 +10,7 @@ import java.util.UUID;
 public interface MatchDto {
     UUID getId();
     String getStatus();
+    LocalDateTime getStatusLastModifiedUTC();
     String getResult();
     UUID getCompetitionId();
     LocalDateTime getStartTimeUTC();
@@ -46,6 +47,7 @@ public interface MatchDto {
     class MatchDtoBuilder {
         private UUID id;
         private String status;
+        private LocalDateTime statusLastModifiedUTC;
         private String result;
         private UUID competitionId;
         private LocalDateTime startTimeUTC;
@@ -66,6 +68,11 @@ public interface MatchDto {
 
         public MatchDtoBuilder status(String status) {
             this.status = status;
+            return this;
+        }
+
+        public MatchDtoBuilder statusLastModifiedUTC(LocalDateTime statusLastModifiedUTC) {
+            this.statusLastModifiedUTC = statusLastModifiedUTC;
             return this;
         }
 
@@ -129,6 +136,11 @@ public interface MatchDto {
                 @Override
                 public String getStatus() {
                     return status;
+                }
+
+                @Override
+                public LocalDateTime getStatusLastModifiedUTC() {
+                    return statusLastModifiedUTC;
                 }
 
                 @Override

--- a/match-service/src/main/java/ml/echelon133/matchservice/match/repository/MatchRepository.java
+++ b/match-service/src/main/java/ml/echelon133/matchservice/match/repository/MatchRepository.java
@@ -29,6 +29,7 @@ public interface MatchRepository extends JpaRepository<Match, UUID> {
                     "   m.half_time_home_goals as halfTimeHomeGoals, m.half_time_away_goals as halfTimeAwayGoals, " +
                     "   m.home_goals as homeGoals, m.away_goals as awayGoals, " +
                     "   m.home_penalties as homePenalties, m.away_penalties as awayPenalties, " +
+                    "   m.status_last_modified_utc as statusLastModifiedUTC, " +
                     "CAST(ht.id as varchar) as homeTeamId, ht.name as homeTeamName, " +
                     "   ht.crest_url as homeTeamCrestUrl, ht.deleted as homeTeamDeleted, " +
                     "CAST(at.id as varchar) as awayTeamId, at.name as awayTeamName, " +
@@ -72,6 +73,7 @@ public interface MatchRepository extends JpaRepository<Match, UUID> {
                     "   m.home_goals as homeGoals, m.away_goals as awayGoals, " +
                     "   m.home_penalties as homePenalties, m.away_penalties as awayPenalties, " +
                     "   m.home_red_cards as homeRedCards, m.away_red_cards as awayRedCards, " +
+                    "   m.status_last_modified_utc as statusLastModifiedUTC, " +
                     "CAST(ht.id as varchar) as homeTeamId, ht.name as homeTeamName, " +
                     "   ht.crest_url as homeTeamCrestUrl, ht.deleted as homeTeamDeleted, " +
                     "CAST(at.id as varchar) as awayTeamId, at.name as awayTeamName, " +
@@ -103,6 +105,7 @@ public interface MatchRepository extends JpaRepository<Match, UUID> {
                     "   m.home_goals as homeGoals, m.away_goals as awayGoals, " +
                     "   m.home_penalties as homePenalties, m.away_penalties as awayPenalties, " +
                     "   m.home_red_cards as homeRedCards, m.away_red_cards as awayRedCards, " +
+                    "   m.status_last_modified_utc as statusLastModifiedUTC, " +
                     "CAST(ht.id as varchar) as homeTeamId, ht.name as homeTeamName, " +
                     "   ht.crest_url as homeTeamCrestUrl, ht.deleted as homeTeamDeleted, " +
                     "CAST(at.id as varchar) as awayTeamId, at.name as awayTeamName, " +
@@ -135,6 +138,7 @@ public interface MatchRepository extends JpaRepository<Match, UUID> {
                     "   m.home_goals as homeGoals, m.away_goals as awayGoals, " +
                     "   m.home_penalties as homePenalties, m.away_penalties as awayPenalties, " +
                     "   m.home_red_cards as homeRedCards, m.away_red_cards as awayRedCards, " +
+                    "   m.status_last_modified_utc as statusLastModifiedUTC, " +
                     "CAST(ht.id as varchar) as homeTeamId, ht.name as homeTeamName, " +
                     "   ht.crest_url as homeTeamCrestUrl, ht.deleted as homeTeamDeleted, " +
                     "CAST(at.id as varchar) as awayTeamId, at.name as awayTeamName, " +

--- a/match-service/src/test/java/ml/echelon133/matchservice/match/TestMatchDto.java
+++ b/match-service/src/test/java/ml/echelon133/matchservice/match/TestMatchDto.java
@@ -17,6 +17,7 @@ public interface TestMatchDto {
         return MatchDto.builder()
                 .id(UUID.randomUUID())
                 .status(MatchStatus.NOT_STARTED.toString())
+                .statusLastModifiedUTC(null)
                 .result(MatchResult.NONE.toString())
                 .competitionId(UUID.randomUUID())
                 .startTimeUTC(LocalDateTime.of(2023, 1, 1, 20, 0))

--- a/match-service/src/test/java/ml/echelon133/matchservice/match/repository/MatchRepositoryTests.java
+++ b/match-service/src/test/java/ml/echelon133/matchservice/match/repository/MatchRepositoryTests.java
@@ -849,12 +849,11 @@ public class MatchRepositoryTests {
 
     private static void assertEntityAndDtoEqual(Match entity, MatchDto dto) {
         // simple fields equal
-        assertTrue(
-                entity.getId().equals(dto.getId()) &&
-                entity.getStatus().toString().equals(dto.getStatus()) &&
-                entity.getCompetitionId().equals(dto.getCompetitionId()) &&
-                entity.getStartTimeUTC().equals(dto.getStartTimeUTC())
-        );
+        assertEquals(dto.getId(), entity.getId());
+        assertEquals(dto.getStatus(), entity.getStatus().toString());
+        assertEquals(dto.getStatusLastModifiedUTC(), entity.getStatusLastModifiedUTC());
+        assertEquals(dto.getCompetitionId(), entity.getCompetitionId());
+        assertEquals(dto.getStartTimeUTC(), entity.getStartTimeUTC());
 
         // home teams equal
         var homeTeamEntity = entity.getHomeTeam();
@@ -862,11 +861,9 @@ public class MatchRepositoryTests {
         if (homeTeamEntity.isDeleted()) {
             assertNull(shortHomeTeamDto);
         } else {
-            assertTrue(
-                    homeTeamEntity.getId().equals(shortHomeTeamDto.getId()) &&
-                    homeTeamEntity.getName().equals(shortHomeTeamDto.getName()) &&
-                    homeTeamEntity.getCrestUrl().equals(shortHomeTeamDto.getCrestUrl())
-            );
+            assertEquals(shortHomeTeamDto.getId(), homeTeamEntity.getId());
+            assertEquals(shortHomeTeamDto.getName(), homeTeamEntity.getName());
+            assertEquals(shortHomeTeamDto.getCrestUrl(), homeTeamEntity.getCrestUrl());
         }
 
         // away teams equal
@@ -875,11 +872,9 @@ public class MatchRepositoryTests {
         if (awayTeamEntity.isDeleted()) {
             assertNull(shortAwayTeamDto);
         } else {
-            assertTrue(
-                    awayTeamEntity.getId().equals(shortAwayTeamDto.getId()) &&
-                    awayTeamEntity.getName().equals(shortAwayTeamDto.getName()) &&
-                    awayTeamEntity.getCrestUrl().equals(shortAwayTeamDto.getCrestUrl())
-            );
+            assertEquals(shortAwayTeamDto.getId(), awayTeamEntity.getId());
+            assertEquals(shortAwayTeamDto.getName(), awayTeamEntity.getName());
+            assertEquals(shortAwayTeamDto.getCrestUrl(), awayTeamEntity.getCrestUrl());
         }
 
         // venues equal
@@ -888,11 +883,9 @@ public class MatchRepositoryTests {
         if (venueEntity.isDeleted()) {
             assertNull(venueDto);
         } else {
-            assertTrue(
-                    venueEntity.getId().equals(venueDto.getId()) &&
-                    venueEntity.getName().equals(venueDto.getName()) &&
-                    venueEntity.getCapacity().equals(venueDto.getCapacity())
-            );
+            assertEquals(venueDto.getId(), venueEntity.getId());
+            assertEquals(venueDto.getName(), venueEntity.getName());
+            assertEquals(venueDto.getCapacity(), venueEntity.getCapacity());
         }
 
         // referees equal
@@ -903,35 +896,27 @@ public class MatchRepositoryTests {
         } else if (refereeEntity.isDeleted()) {
             assertNull(refereeDto);
         } else {
-            assertTrue(
-                    refereeEntity.getId().equals(refereeDto.getId()) &&
-                    refereeEntity.getName().equals(refereeDto.getName())
-            );
+            assertEquals(refereeDto.getId(), refereeEntity.getId());
+            assertEquals(refereeDto.getName(), refereeEntity.getName());
         }
 
         // half time scores equal
         var halfTimeScoreEntity = entity.getHalfTimeScoreInfo();
         var halfTimeScoreDto = dto.getHalfTimeScoreInfo();
-        assertTrue(
-                halfTimeScoreEntity.getHomeGoals().equals(halfTimeScoreDto.getHomeGoals()) &&
-                halfTimeScoreDto.getAwayGoals().equals(halfTimeScoreDto.getAwayGoals())
-        );
+        assertEquals(halfTimeScoreDto.getHomeGoals(), halfTimeScoreEntity.getHomeGoals());
+        assertEquals(halfTimeScoreDto.getAwayGoals(), halfTimeScoreEntity.getAwayGoals());
 
         // scores equal
         var scoreEntity = entity.getScoreInfo();
         var scoreDto = dto.getScoreInfo();
-        assertTrue(
-                scoreEntity.getHomeGoals().equals(scoreDto.getHomeGoals()) &&
-                scoreEntity.getAwayGoals().equals(scoreDto.getAwayGoals())
-        );
+        assertEquals(scoreDto.getHomeGoals(), scoreEntity.getHomeGoals());
+        assertEquals(scoreDto.getAwayGoals(), scoreEntity.getAwayGoals());
 
         // penalties equal
         var penaltiesEntity = entity.getPenaltiesInfo();
         var penaltiesDto = dto.getPenaltiesInfo();
-        assertTrue(
-                penaltiesEntity.getHomeGoals().equals(penaltiesDto.getHomeGoals()) &&
-                penaltiesEntity.getAwayGoals().equals(penaltiesDto.getAwayGoals())
-        );
+        assertEquals(penaltiesDto.getHomeGoals(), penaltiesEntity.getHomeGoals());
+        assertEquals(penaltiesDto.getAwayGoals(), penaltiesEntity.getAwayGoals());
 
         // results equal
         var resultDto = (dto.getResult() == null) ? null : MatchResult.valueOf(dto.getResult());
@@ -940,12 +925,11 @@ public class MatchRepositoryTests {
 
     private static void assertEntityAndDtoEqual(Match entity, CompactMatchDto dto) {
         // simple fields equal
-        assertTrue(
-                entity.getId().equals(dto.getId()) &&
-                        entity.getStatus().toString().equals(dto.getStatus()) &&
-                        entity.getCompetitionId().equals(dto.getCompetitionId()) &&
-                        entity.getStartTimeUTC().equals(dto.getStartTimeUTC())
-        );
+        assertEquals(dto.getId(), entity.getId());
+        assertEquals(dto.getStatus(), entity.getStatus().toString());
+        assertEquals(dto.getStatusLastModifiedUTC(), entity.getStatusLastModifiedUTC());
+        assertEquals(dto.getCompetitionId(), entity.getCompetitionId());
+        assertEquals(dto.getStartTimeUTC(), entity.getStartTimeUTC());
 
         // home teams equal
         var homeTeamEntity = entity.getHomeTeam();
@@ -953,11 +937,9 @@ public class MatchRepositoryTests {
         if (homeTeamEntity.isDeleted()) {
             assertNull(shortHomeTeamDto);
         } else {
-            assertTrue(
-                    homeTeamEntity.getId().equals(shortHomeTeamDto.getId()) &&
-                            homeTeamEntity.getName().equals(shortHomeTeamDto.getName()) &&
-                            homeTeamEntity.getCrestUrl().equals(shortHomeTeamDto.getCrestUrl())
-            );
+            assertEquals(shortHomeTeamDto.getId(), homeTeamEntity.getId());
+            assertEquals(shortHomeTeamDto.getName(), homeTeamEntity.getName());
+            assertEquals(shortHomeTeamDto.getCrestUrl(), homeTeamEntity.getCrestUrl());
         }
 
         // away teams equal
@@ -966,36 +948,28 @@ public class MatchRepositoryTests {
         if (awayTeamEntity.isDeleted()) {
             assertNull(shortAwayTeamDto);
         } else {
-            assertTrue(
-                    awayTeamEntity.getId().equals(shortAwayTeamDto.getId()) &&
-                            awayTeamEntity.getName().equals(shortAwayTeamDto.getName()) &&
-                            awayTeamEntity.getCrestUrl().equals(shortAwayTeamDto.getCrestUrl())
-            );
+            assertEquals(shortAwayTeamDto.getId(), awayTeamEntity.getId());
+            assertEquals(shortAwayTeamDto.getName(), awayTeamEntity.getName());
+            assertEquals(shortAwayTeamDto.getCrestUrl(), awayTeamEntity.getCrestUrl());
         }
 
         // half time scores equal
         var halfTimeScoreEntity = entity.getHalfTimeScoreInfo();
         var halfTimeScoreDto = dto.getHalfTimeScoreInfo();
-        assertTrue(
-                halfTimeScoreEntity.getHomeGoals().equals(halfTimeScoreDto.getHomeGoals()) &&
-                        halfTimeScoreDto.getAwayGoals().equals(halfTimeScoreDto.getAwayGoals())
-        );
+        assertEquals(halfTimeScoreDto.getHomeGoals(), halfTimeScoreEntity.getHomeGoals());
+        assertEquals(halfTimeScoreDto.getAwayGoals(), halfTimeScoreEntity.getAwayGoals());
 
         // scores equal
         var scoreEntity = entity.getScoreInfo();
         var scoreDto = dto.getScoreInfo();
-        assertTrue(
-                scoreEntity.getHomeGoals().equals(scoreDto.getHomeGoals()) &&
-                        scoreEntity.getAwayGoals().equals(scoreDto.getAwayGoals())
-        );
+        assertEquals(scoreDto.getHomeGoals(), scoreEntity.getHomeGoals());
+        assertEquals(scoreDto.getAwayGoals(), scoreEntity.getAwayGoals());
 
         // penalties equal
         var penaltiesEntity = entity.getPenaltiesInfo();
         var penaltiesDto = dto.getPenaltiesInfo();
-        assertTrue(
-                penaltiesEntity.getHomeGoals().equals(penaltiesDto.getHomeGoals()) &&
-                penaltiesEntity.getAwayGoals().equals(penaltiesDto.getAwayGoals())
-        );
+        assertEquals(penaltiesDto.getHomeGoals(), penaltiesEntity.getHomeGoals());
+        assertEquals(penaltiesDto.getAwayGoals(), penaltiesEntity.getAwayGoals());
 
         // results equal
         var resultDto = (dto.getResult() == null) ? null : MatchResult.valueOf(dto.getResult());


### PR DESCRIPTION
When the status of a match is modified, set `statusLastModifiedUTC` value to allow for the approximation of the match clock.

## Examples of usage

### First Half

The client fetches the status of the match, which contains information about the match currently being in it's first half.
The difference between the current date and the date of last modification of the status can be converted into minutes. Since the first half starts from the 1st minute, we add 1 to the minutes we have calculated in the previous step. This gives us the approximate value of the clock in the game at that moment.

### Second Half

Just as before, we calculate the difference between the current date and the date of last modification of the status, then convert it into minutes. Since the second half starts from the 45th minute, we add 45 to the minutes we have calculated in the previous step, which again gives us the approximate value of the clock in the game at that moment.