### PR TITLE
Feature/store lineup formation

### DIFF
--- a/match-service/src/main/java/ml/echelon133/matchservice/match/controller/MatchController.java
+++ b/match-service/src/main/java/ml/echelon133/matchservice/match/controller/MatchController.java
@@ -4,13 +4,9 @@ import ml.echelon133.common.exception.RequestBodyContentInvalidException;
 import ml.echelon133.common.exception.RequestParamsInvalidException;
 import ml.echelon133.common.exception.ResourceNotFoundException;
 import ml.echelon133.common.exception.ValidationResultMapper;
-import ml.echelon133.matchservice.match.model.CompactMatchDto;
-import ml.echelon133.matchservice.match.model.LineupDto;
-import ml.echelon133.matchservice.match.model.MatchDto;
 import ml.echelon133.matchservice.match.controller.validators.MatchCriteriaValidator;
 import ml.echelon133.matchservice.match.exceptions.LineupPlayerInvalidException;
-import ml.echelon133.matchservice.match.model.UpsertLineupDto;
-import ml.echelon133.matchservice.match.model.UpsertMatchDto;
+import ml.echelon133.matchservice.match.model.*;
 import ml.echelon133.matchservice.match.service.MatchService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
@@ -121,9 +117,10 @@ public class MatchController {
         return matchService.findMatchLineup(matchId);
     }
 
-    @PutMapping("/{matchId}/lineups/home")
-    public void updateHomeLineup(
+    @PutMapping("/{matchId}/lineups/{side:home|away}")
+    public void updateLineup(
             @PathVariable UUID matchId,
+            @PathVariable String side,
             @RequestBody @Valid UpsertLineupDto lineupDto,
             BindingResult result
     ) throws RequestBodyContentInvalidException, ResourceNotFoundException, LineupPlayerInvalidException {
@@ -131,19 +128,12 @@ public class MatchController {
         if (result.hasErrors()) {
             throw new RequestBodyContentInvalidException(ValidationResultMapper.resultIntoErrorMap(result));
         }
-        matchService.updateHomeLineup(matchId, lineupDto);
-    }
 
-    @PutMapping("/{matchId}/lineups/away")
-    public void updateAwayLineup(
-            @PathVariable UUID matchId,
-            @RequestBody @Valid UpsertLineupDto lineupDto,
-            BindingResult result
-    ) throws RequestBodyContentInvalidException, ResourceNotFoundException, LineupPlayerInvalidException {
-
-        if (result.hasErrors()) {
-            throw new RequestBodyContentInvalidException(ValidationResultMapper.resultIntoErrorMap(result));
+        // side's regex guarantees that its value is either 'home' or 'away'
+        if (side.equals("home")) {
+            matchService.updateHomeLineup(matchId, lineupDto);
+        } else {
+            matchService.updateAwayLineup(matchId, lineupDto);
         }
-        matchService.updateAwayLineup(matchId, lineupDto);
     }
 }

--- a/match-service/src/main/java/ml/echelon133/matchservice/match/model/Lineup.java
+++ b/match-service/src/main/java/ml/echelon133/matchservice/match/model/Lineup.java
@@ -26,6 +26,9 @@ public class Lineup extends BaseEntity {
     )
     List<TeamPlayer> substitutePlayers;
 
+    @Column(length = 10)
+    private String formation;
+
     public Lineup() {
         this.startingPlayers = new ArrayList<>();
         this.substitutePlayers = new ArrayList<>();
@@ -33,6 +36,14 @@ public class Lineup extends BaseEntity {
     public Lineup(List<TeamPlayer> startingPlayers, List<TeamPlayer> substitutePlayers) {
         this.startingPlayers = startingPlayers;
         this.substitutePlayers = substitutePlayers;
+    }
+    public Lineup(
+            List<TeamPlayer> startingPlayers,
+            List<TeamPlayer> substitutePlayers,
+            String formation
+    ) {
+        this(startingPlayers, substitutePlayers);
+        this.formation = formation;
     }
 
     public List<TeamPlayer> getStartingPlayers() {
@@ -49,5 +60,13 @@ public class Lineup extends BaseEntity {
 
     public void setSubstitutePlayers(List<TeamPlayer> substitutePlayers) {
         this.substitutePlayers = substitutePlayers;
+    }
+
+    public String getFormation() {
+        return formation;
+    }
+
+    public void setFormation(String formation) {
+        this.formation = formation;
     }
 }

--- a/match-service/src/main/java/ml/echelon133/matchservice/match/model/LineupDto.java
+++ b/match-service/src/main/java/ml/echelon133/matchservice/match/model/LineupDto.java
@@ -22,10 +22,25 @@ public class LineupDto {
         this.home = new TeamLineup(homeStartingPlayers, homeSubstitutePlayers);
         this.away = new TeamLineup(awayStartingPlayers, awaySubstitutePlayers);
     }
+    public LineupDto(
+            List<TeamPlayerDto> homeStartingPlayers,
+            List<TeamPlayerDto> homeSubstitutePlayers,
+            List<TeamPlayerDto> awayStartingPlayers,
+            List<TeamPlayerDto> awaySubstitutePlayers,
+            LineupFormationsDto lineupFormations
+    ) {
+        this.home = new TeamLineup(
+                homeStartingPlayers, homeSubstitutePlayers, lineupFormations.getHomeFormation()
+        );
+        this.away = new TeamLineup(
+                awayStartingPlayers, awaySubstitutePlayers, lineupFormations.getAwayFormation()
+        );
+    }
 
     public static class TeamLineup {
         private final List<TeamPlayerDto> startingPlayers;
         private final List<TeamPlayerDto> substitutePlayers;
+        private String formation;
 
         public TeamLineup() {
             this.startingPlayers = List.of();
@@ -35,6 +50,14 @@ public class LineupDto {
             this.startingPlayers = startingPlayers;
             this.substitutePlayers = substitutePlayers;
         }
+        public TeamLineup(
+                List<TeamPlayerDto> startingPlayers,
+                List<TeamPlayerDto> substitutePlayers,
+                String formation
+        ) {
+            this(startingPlayers, substitutePlayers);
+            this.formation = formation;
+        }
 
         public List<TeamPlayerDto> getStartingPlayers() {
             return startingPlayers;
@@ -42,6 +65,10 @@ public class LineupDto {
 
         public List<TeamPlayerDto> getSubstitutePlayers() {
             return substitutePlayers;
+        }
+
+        public String getFormation() {
+            return formation;
         }
     }
 

--- a/match-service/src/main/java/ml/echelon133/matchservice/match/model/LineupFormationsDto.java
+++ b/match-service/src/main/java/ml/echelon133/matchservice/match/model/LineupFormationsDto.java
@@ -1,0 +1,20 @@
+package ml.echelon133.matchservice.match.model;
+
+public interface LineupFormationsDto {
+    String getHomeFormation();
+    String getAwayFormation();
+
+    static LineupFormationsDto from(String homeFormation, String awayFormation) {
+        return new LineupFormationsDto() {
+            @Override
+            public String getHomeFormation() {
+                return homeFormation;
+            }
+
+            @Override
+            public String getAwayFormation() {
+                return awayFormation;
+            }
+        };
+    }
+}

--- a/match-service/src/main/java/ml/echelon133/matchservice/match/model/UpsertLineupDto.java
+++ b/match-service/src/main/java/ml/echelon133/matchservice/match/model/UpsertLineupDto.java
@@ -1,5 +1,6 @@
 package ml.echelon133.matchservice.match.model;
 
+import ml.echelon133.matchservice.match.model.constraints.FormationCorrect;
 import ml.echelon133.matchservice.match.model.constraints.PlayerIdsUnique;
 import ml.echelon133.matchservice.team.constraints.TeamPlayerExists;
 
@@ -17,10 +18,17 @@ public class UpsertLineupDto {
     @NotNull
     private List<@TeamPlayerExists String> substitutePlayers;
 
+    @FormationCorrect
+    private String formation;
+
     public UpsertLineupDto() {}
     public UpsertLineupDto(List<String> startingPlayers, List<String> substitutePlayers) {
         this.startingPlayers = startingPlayers;
         this.substitutePlayers = substitutePlayers;
+    }
+    public UpsertLineupDto(List<String> startingPlayers, List<String> substitutePlayers, String formation) {
+        this(startingPlayers, substitutePlayers);
+        this.formation = formation;
     }
 
     public List<String> getStartingPlayers() {
@@ -37,5 +45,13 @@ public class UpsertLineupDto {
 
     public void setSubstitutePlayers(List<String> substitutePlayers) {
         this.substitutePlayers = substitutePlayers;
+    }
+
+    public String getFormation() {
+        return formation;
+    }
+
+    public void setFormation(String formation) {
+        this.formation = formation;
     }
 }

--- a/match-service/src/main/java/ml/echelon133/matchservice/match/model/constraints/FormationCorrect.java
+++ b/match-service/src/main/java/ml/echelon133/matchservice/match/model/constraints/FormationCorrect.java
@@ -1,0 +1,58 @@
+package ml.echelon133.matchservice.match.model.constraints;
+
+import javax.validation.Constraint;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import javax.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Arrays;
+import java.util.regex.Pattern;
+
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = FormationCorrect.Validator.class)
+public @interface FormationCorrect {
+    String message() default "provided formation is invalid";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+
+    class Validator implements ConstraintValidator<FormationCorrect, String> {
+
+        // regex for initial verification of the formation's format:
+        //      * should start with a digit in the 1-5 range
+        //      * repeats a group consisting of a single hyphen, followed by a digit in the 1-5 range
+        //              (group repeats at least 2 times, at most 4 times)
+        //
+        // an input which satisfies this regex needs further validation, since an example input such as "5-5-5"
+        // is a match, despite the fact that it refers to 15 players, when it must refer exactly to 10 players
+        private static final Pattern FORMATION_PATTERN = Pattern.compile("^([1-5])(-[1-5]){2,4}$");
+
+        @Override
+        public boolean isValid(String formation, ConstraintValidatorContext constraintValidatorContext) {
+            // let @NotNull handle this case if it's present
+            if (formation == null) {
+                return true;
+            }
+
+            // a formation string is valid if:
+            //      * it matches the regex
+            //      * it refers to exactly 10 players
+            if (FORMATION_PATTERN.matcher(formation).matches()) {
+                // split formation string around hyphens, e.g. 4-4-2 should become {"4", "4", "2"}
+                String[] formationRows = formation.split("-");
+
+                // the formation string should refer to EXACTLY 10 players (the goalkeeper's position is implicit)
+                var playerCount = Arrays.stream(formationRows)
+                        .map(Integer::valueOf)
+                        .reduce(0, Integer::sum);
+
+                return playerCount == 10;
+            }
+
+            return false;
+        }
+    }
+}

--- a/match-service/src/main/java/ml/echelon133/matchservice/match/repository/MatchRepository.java
+++ b/match-service/src/main/java/ml/echelon133/matchservice/match/repository/MatchRepository.java
@@ -1,9 +1,10 @@
 package ml.echelon133.matchservice.match.repository;
 
 import ml.echelon133.matchservice.match.model.CompactMatchDto;
+import ml.echelon133.matchservice.match.model.LineupFormationsDto;
+import ml.echelon133.matchservice.match.model.Match;
 import ml.echelon133.matchservice.match.model.MatchDto;
 import ml.echelon133.matchservice.team.model.TeamPlayerDto;
-import ml.echelon133.matchservice.match.model.Match;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -237,4 +238,21 @@ public interface MatchRepository extends JpaRepository<Match, UUID> {
             nativeQuery = true
     )
     List<TeamPlayerDto> findAwaySubstitutePlayersByMatchId(UUID matchId);
+
+    /**
+     * Finds formations of both lineups of a match with the specified id.
+     *
+     * @param matchId id of the match whose lineup formations need to be found
+     * @return an {@link Optional} containing a dto with lineup formations of both teams playing in a match (if the match exists),
+     *      otherwise the optional is empty
+     */
+    @Query(
+            value = "SELECT home_lineup.formation as homeFormation, away_lineup.formation as awayFormation " +
+                    "FROM match m " +
+                    "JOIN lineup home_lineup ON m.home_lineup_id = home_lineup.id " +
+                    "JOIN lineup away_lineup ON m.away_lineup_id = away_lineup.id " +
+                    "WHERE m.deleted = false AND m.id = :matchId",
+            nativeQuery = true
+    )
+    Optional<LineupFormationsDto> findLineupFormationsByMatchId(UUID matchId);
 }

--- a/match-service/src/main/java/ml/echelon133/matchservice/match/service/MatchService.java
+++ b/match-service/src/main/java/ml/echelon133/matchservice/match/service/MatchService.java
@@ -3,15 +3,9 @@ package ml.echelon133.matchservice.match.service;
 import ml.echelon133.common.constants.DateFormatConstants;
 import ml.echelon133.common.exception.ResourceNotFoundException;
 import ml.echelon133.common.match.MatchStatus;
-import ml.echelon133.matchservice.match.model.CompactMatchDto;
-import ml.echelon133.matchservice.match.model.LineupDto;
-import ml.echelon133.matchservice.match.model.MatchDto;
+import ml.echelon133.matchservice.match.model.*;
 import ml.echelon133.matchservice.team.model.TeamPlayerDto;
 import ml.echelon133.matchservice.match.exceptions.LineupPlayerInvalidException;
-import ml.echelon133.matchservice.match.model.Lineup;
-import ml.echelon133.matchservice.match.model.Match;
-import ml.echelon133.matchservice.match.model.UpsertLineupDto;
-import ml.echelon133.matchservice.match.model.UpsertMatchDto;
 import ml.echelon133.matchservice.match.repository.MatchRepository;
 import ml.echelon133.matchservice.referee.service.RefereeService;
 import ml.echelon133.matchservice.team.model.Team;
@@ -268,7 +262,9 @@ public class MatchService {
             matchRepository.findHomeStartingPlayersByMatchId(matchId),
             matchRepository.findHomeSubstitutePlayersByMatchId(matchId),
             matchRepository.findAwayStartingPlayersByMatchId(matchId),
-            matchRepository.findAwaySubstitutePlayersByMatchId(matchId)
+            matchRepository.findAwaySubstitutePlayersByMatchId(matchId),
+            matchRepository.findLineupFormationsByMatchId(matchId)
+                    .orElse(LineupFormationsDto.from(null, null))
         );
     }
 
@@ -360,6 +356,7 @@ public class MatchService {
         Lineup lineup = homeLineup ? match.getHomeLineup() : match.getAwayLineup();
         lineup.setStartingPlayers(startingPlayers);
         lineup.setSubstitutePlayers(substitutePlayers);
+        lineup.setFormation(lineupDto.getFormation());
         matchRepository.save(match);
     }
 }

--- a/match-service/src/test/java/ml/echelon133/matchservice/match/controller/MatchControllerTests.java
+++ b/match-service/src/test/java/ml/echelon133/matchservice/match/controller/MatchControllerTests.java
@@ -1503,6 +1503,33 @@ public class MatchControllerTests {
     }
 
     @Test
+    @DisplayName("PUT /api/matches/:id/lineups/home returns 200 when the lineup is validated")
+    public void updateHomeLineup_LineupValid_StatusOk() throws Exception {
+        var matchId = UUID.randomUUID();
+
+        // 11 unique starting players
+        List<String> startingPlayers = generateRandomStringIds(11);
+        // 5 unique substitute players
+        List<String> substitutePlayers = generateRandomStringIds(5);
+
+        var json = jsonUpsertLineupDto.write(new UpsertLineupDto(
+                startingPlayers, substitutePlayers
+        )).getJson();
+
+        // given
+        given(teamPlayerRepository.existsByIdAndDeletedFalse(any())).willReturn(true);
+
+        // when
+        mvc.perform(
+                        put("/api/matches/" + matchId + "/lineups/home")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .accept(MediaType.APPLICATION_JSON)
+                                .content(json)
+                )
+                .andExpect(status().isOk());
+    }
+
+    @Test
     @DisplayName("PUT /api/matches/:id/lineups/away returns 422 when starting players not provided")
     public void updateAwayLineup_StartingPlayersNotProvided_StatusUnprocessableEntity() throws Exception {
         var matchId = UUID.randomUUID();
@@ -1797,6 +1824,33 @@ public class MatchControllerTests {
                                 .content(json)
                 )
                 .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("PUT /api/matches/:id/lineups/away returns 200 when the lineup is validated")
+    public void updateAwayLineup_LineupValid_StatusOk() throws Exception {
+        var matchId = UUID.randomUUID();
+
+        // 11 unique starting players
+        List<String> startingPlayers = generateRandomStringIds(11);
+        // 5 unique substitute players
+        List<String> substitutePlayers = generateRandomStringIds(5);
+
+        var json = jsonUpsertLineupDto.write(new UpsertLineupDto(
+                startingPlayers, substitutePlayers
+        )).getJson();
+
+        // given
+        given(teamPlayerRepository.existsByIdAndDeletedFalse(any())).willReturn(true);
+
+        // when
+        mvc.perform(
+                        put("/api/matches/" + matchId + "/lineups/away")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .accept(MediaType.APPLICATION_JSON)
+                                .content(json)
+                )
+                .andExpect(status().isOk());
     }
 
     private List<String> generateRandomStringIds(int numberOfIds) {

--- a/match-service/src/test/java/ml/echelon133/matchservice/match/controller/MatchControllerTests.java
+++ b/match-service/src/test/java/ml/echelon133/matchservice/match/controller/MatchControllerTests.java
@@ -1503,6 +1503,75 @@ public class MatchControllerTests {
     }
 
     @Test
+    @DisplayName("PUT /api/matches/:id/lineups/home returns 422 when the formation is invalid")
+    public void updateHomeLineup_FormationInvalid_StatusOk() throws Exception {
+        var invalidFormations = List.of(
+                "asdf", "0-0-0-0-0", "11", "5-5", "a-b-c-d", "----", "442", "4321"
+        );
+
+        var matchId = UUID.randomUUID();
+
+        // 11 unique starting players
+        List<String> startingPlayers = generateRandomStringIds(11);
+        // 5 unique substitute players
+        List<String> substitutePlayers = generateRandomStringIds(5);
+
+        // given
+        given(teamPlayerRepository.existsByIdAndDeletedFalse(any())).willReturn(true);
+
+        for (var invalidFormation : invalidFormations) {
+            var json = jsonUpsertLineupDto.write(new UpsertLineupDto(
+                    startingPlayers, substitutePlayers, invalidFormation
+            )).getJson();
+
+            // when
+            mvc.perform(
+                            put("/api/matches/" + matchId + "/lineups/home")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .accept(MediaType.APPLICATION_JSON)
+                                    .content(json)
+                    )
+                    .andExpect(status().isUnprocessableEntity())
+                    .andExpect(jsonPath("$.messages", hasEntry("formation", List.of("provided formation is invalid"))));
+        }
+    }
+
+    @Test
+    @DisplayName("PUT /api/matches/:id/lineups/home returns 200 when the formation is valid")
+    public void updateHomeLineup_FormationValid_StatusOk() throws Exception {
+        var validFormations = List.of(
+                "2-3-5", "2-3-2-3", "3-2-5", "3-4-3", "3-3-4",
+                "4-2-4", "4-4-2", "4-4-1-1", "4-1-2-1-2", "4-1-3-2",
+                "4-3-3", "4-3-1-2", "4-5-1"
+        );
+
+        var matchId = UUID.randomUUID();
+
+        // 11 unique starting players
+        List<String> startingPlayers = generateRandomStringIds(11);
+        // 5 unique substitute players
+        List<String> substitutePlayers = generateRandomStringIds(5);
+
+        // given
+        given(teamPlayerRepository.existsByIdAndDeletedFalse(any())).willReturn(true);
+
+        for (var validFormation : validFormations) {
+            var json = jsonUpsertLineupDto.write(new UpsertLineupDto(
+                    startingPlayers, substitutePlayers, validFormation
+            )).getJson();
+
+            // when
+            mvc.perform(
+                            put("/api/matches/" + matchId + "/lineups/home")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .accept(MediaType.APPLICATION_JSON)
+                                    .content(json)
+                    )
+                    .andExpect(status().isOk());
+        }
+    }
+
+    @Test
     @DisplayName("PUT /api/matches/:id/lineups/home returns 200 when the lineup is validated")
     public void updateHomeLineup_LineupValid_StatusOk() throws Exception {
         var matchId = UUID.randomUUID();
@@ -1824,6 +1893,75 @@ public class MatchControllerTests {
                                 .content(json)
                 )
                 .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("PUT /api/matches/:id/lineups/away returns 422 when the formation is invalid")
+    public void updateAwayLineup_FormationInvalid_StatusOk() throws Exception {
+        var invalidFormations = List.of(
+                "asdf", "0-0-0-0-0", "11", "5-5", "a-b-c-d", "----", "442", "4321"
+        );
+
+        var matchId = UUID.randomUUID();
+
+        // 11 unique starting players
+        List<String> startingPlayers = generateRandomStringIds(11);
+        // 5 unique substitute players
+        List<String> substitutePlayers = generateRandomStringIds(5);
+
+        // given
+        given(teamPlayerRepository.existsByIdAndDeletedFalse(any())).willReturn(true);
+
+        for (var invalidFormation : invalidFormations) {
+            var json = jsonUpsertLineupDto.write(new UpsertLineupDto(
+                    startingPlayers, substitutePlayers, invalidFormation
+            )).getJson();
+
+            // when
+            mvc.perform(
+                            put("/api/matches/" + matchId + "/lineups/away")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .accept(MediaType.APPLICATION_JSON)
+                                    .content(json)
+                    )
+                    .andExpect(status().isUnprocessableEntity())
+                    .andExpect(jsonPath("$.messages", hasEntry("formation", List.of("provided formation is invalid"))));
+        }
+    }
+
+    @Test
+    @DisplayName("PUT /api/matches/:id/lineups/away returns 200 when the formation is valid")
+    public void updateAwayLineup_FormationValid_StatusOk() throws Exception {
+        var validFormations = List.of(
+                "2-3-5", "2-3-2-3", "3-2-5", "3-4-3", "3-3-4",
+                "4-2-4", "4-4-2", "4-4-1-1", "4-1-2-1-2", "4-1-3-2",
+                "4-3-3", "4-3-1-2", "4-5-1"
+        );
+
+        var matchId = UUID.randomUUID();
+
+        // 11 unique starting players
+        List<String> startingPlayers = generateRandomStringIds(11);
+        // 5 unique substitute players
+        List<String> substitutePlayers = generateRandomStringIds(5);
+
+        // given
+        given(teamPlayerRepository.existsByIdAndDeletedFalse(any())).willReturn(true);
+
+        for (var validFormation : validFormations) {
+            var json = jsonUpsertLineupDto.write(new UpsertLineupDto(
+                    startingPlayers, substitutePlayers, validFormation
+            )).getJson();
+
+            // when
+            mvc.perform(
+                            put("/api/matches/" + matchId + "/lineups/away")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .accept(MediaType.APPLICATION_JSON)
+                                    .content(json)
+                    )
+                    .andExpect(status().isOk());
+        }
     }
 
     @Test

--- a/match-service/src/test/java/ml/echelon133/matchservice/match/repository/MatchRepositoryTests.java
+++ b/match-service/src/test/java/ml/echelon133/matchservice/match/repository/MatchRepositoryTests.java
@@ -1152,6 +1152,54 @@ public class MatchRepositoryTests {
         assertLineupContainsPlayers(awaySubstitutePlayers2, match2.getAwayLineup().getSubstitutePlayers());
     }
 
+    @Test
+    @DisplayName("findLineupFormationsByMatchId native query returns an empty result when match does not exist")
+    public void findLineupFormationsByMatchId_MatchNotFound_ResultEmpty() {
+        var matchId = UUID.randomUUID();
+
+        // when
+        var lineupFormations = matchRepository.findLineupFormationsByMatchId(matchId);
+
+        // then
+        assertTrue(lineupFormations.isEmpty());
+    }
+
+    @Test
+    @DisplayName("findLineupFormationsByMatchId native query returns null for both home and away formations when they are set to default values")
+    public void findLineupFormationsByMatchId_MatchWithEmptyLineup_BothFormationsAreNull() {
+        var matchId = UUID.randomUUID();
+        matchRepository.save(TestMatch.builder().id(matchId).build());
+
+        // when
+        var lineupFormations = matchRepository.findLineupFormationsByMatchId(matchId);
+
+        // then
+        assertTrue(lineupFormations.isPresent());
+        assertNull(lineupFormations.get().getHomeFormation());
+        assertNull(lineupFormations.get().getAwayFormation());
+    }
+
+    @Test
+    @DisplayName("findLineupFormationsByMatchId native query returns correct values for both home and away formations when they are set to custom values")
+    public void findLineupFormationsByMatchId_MatchWithSetLineup_BothFormationsAreCorrect() {
+        var match = TestMatchLineup.createTestMatchWithLineup();
+        // set both home and away formations
+        var expectedHomeFormation = "4-4-2";
+        var expectedAwayFormation = "4-3-3";
+        match.getHomeLineup().setFormation(expectedHomeFormation);
+        match.getAwayLineup().setFormation(expectedAwayFormation);
+        matchRepository.save(match);
+        var matchId = match.getId();
+
+        // when
+        var lineupFormations = matchRepository.findLineupFormationsByMatchId(matchId);
+
+        // then
+        assertTrue(lineupFormations.isPresent());
+        assertEquals(expectedHomeFormation, lineupFormations.get().getHomeFormation());
+        assertEquals(expectedAwayFormation, lineupFormations.get().getAwayFormation());
+    }
+
     private static void assertLineupContainsPlayers(List<TeamPlayerDto> foundLineup, List<TeamPlayer> expectedLineup) {
         var foundIds = foundLineup.stream().map(TeamPlayerDto::getId).collect(Collectors.toList());
         var expectedIds = expectedLineup.stream().map(BaseEntity::getId).collect(Collectors.toList());


### PR DESCRIPTION
Stores information about the formations of both teams playing in a particular match.

Formation field accepts strings which represent rows of players on the pitch, separated by a hyphen. Valid formations include: "4-4-2", "4-3-3", "4-2-1-3", etc. The number of players specified by the formation string must be **exactly** 10. There can be at most 5 digit groups, therefore a formation such as "4-1-1-1-1-1-1" will not be accepted, despite the fact that it specifies the position of 10 players.

Now both **PUT /api/matches/{matchId}/lineups/home** and **PUT /api/matches/{matchId}/lineups/away** accept an optional `formation` field in their payloads.

```JSON
{
    "startingPlayers": [],
    "substitutePlayers": [],
    "formation": "4-4-2"
}
```

The response from **GET /api/matches/{matchId}/lineups** now provides the `formation` field for each lineup.

```JSON
{
    "home": {
        "startingPlayers": [],
        "substitutePlayers":[],
        "formation": "4-4-2"
    },
    "away": {
        "startingPlayers": [],
        "substitutePlayers":[],
        "formation": "4-3-3"
    },
}
```