### PR TITLE
Feature/pin competitions

### DIFF
--- a/competition-service/src/main/java/pl/echelon133/competitionservice/competition/controller/CompetitionController.java
+++ b/competition-service/src/main/java/pl/echelon133/competitionservice/competition/controller/CompetitionController.java
@@ -1,6 +1,6 @@
 package pl.echelon133.competitionservice.competition.controller;
 
-import pl.echelon133.competitionservice.competition.model.CompetitionDto;
+import jakarta.validation.Valid;
 import ml.echelon133.common.exception.RequestBodyContentInvalidException;
 import ml.echelon133.common.exception.ResourceNotFoundException;
 import ml.echelon133.common.exception.ValidationResultMapper;
@@ -11,12 +11,13 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 import pl.echelon133.competitionservice.competition.exceptions.CompetitionInvalidException;
+import pl.echelon133.competitionservice.competition.model.CompetitionDto;
 import pl.echelon133.competitionservice.competition.model.PlayerStatsDto;
 import pl.echelon133.competitionservice.competition.model.StandingsDto;
 import pl.echelon133.competitionservice.competition.model.UpsertCompetitionDto;
 import pl.echelon133.competitionservice.competition.service.CompetitionService;
 
-import jakarta.validation.Valid;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -44,6 +45,11 @@ public class CompetitionController {
     @GetMapping
     public Page<CompetitionDto> getCompetitionsByName(Pageable pageable, @RequestParam String name) {
         return competitionService.findCompetitionsByName(name, pageable);
+    }
+
+    @GetMapping("/pinned")
+    public List<CompetitionDto> getPinnedCompetitions() {
+        return competitionService.findPinnedCompetitions();
     }
 
     @PostMapping

--- a/competition-service/src/main/java/pl/echelon133/competitionservice/competition/model/Competition.java
+++ b/competition-service/src/main/java/pl/echelon133/competitionservice/competition/model/Competition.java
@@ -26,6 +26,8 @@ public class Competition extends BaseEntity {
     @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Legend> legend;
 
+    private boolean pinned;
+
     public Competition() {}
     public Competition(String name, String season, String logoUrl) {
         this.name = name;
@@ -76,5 +78,13 @@ public class Competition extends BaseEntity {
 
     public void setLegend(List<Legend> legend) {
         this.legend = legend;
+    }
+
+    public boolean isPinned() {
+        return pinned;
+    }
+
+    public void setPinned(boolean pinned) {
+        this.pinned = pinned;
     }
 }

--- a/competition-service/src/main/java/pl/echelon133/competitionservice/competition/model/UpsertCompetitionDto.java
+++ b/competition-service/src/main/java/pl/echelon133/competitionservice/competition/model/UpsertCompetitionDto.java
@@ -20,7 +20,8 @@ public record UpsertCompetitionDto(
     @NotNull @Length(min = 1, max = 30) String season,
     @NotNull @URL @Length(min = 15, max = 500) String logoUrl,
     @Size(min = 1, max = 10) @TeamsUniqueInGroups List<@Valid UpsertGroupDto> groups,
-    @Size(max = 6) @PositionsUniqueInLegend List<@Valid UpsertLegendDto> legend
+    @Size(max = 6) @PositionsUniqueInLegend List<@Valid UpsertLegendDto> legend,
+    boolean pinned
 ) {
     public record UpsertGroupDto(
         @NotNull @Length(max = 50) String name,

--- a/competition-service/src/main/java/pl/echelon133/competitionservice/competition/repository/CompetitionRepository.java
+++ b/competition-service/src/main/java/pl/echelon133/competitionservice/competition/repository/CompetitionRepository.java
@@ -1,14 +1,15 @@
 package pl.echelon133.competitionservice.competition.repository;
 
-import pl.echelon133.competitionservice.competition.model.CompetitionDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import pl.echelon133.competitionservice.competition.model.Competition;
+import pl.echelon133.competitionservice.competition.model.CompetitionDto;
 import pl.echelon133.competitionservice.competition.model.PlayerStatsDto;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -59,6 +60,22 @@ public interface CompetitionRepository extends JpaRepository<Competition, UUID> 
             nativeQuery = true
     )
     Page<CompetitionDto> findAllByNameContaining(String phrase, Pageable pageable);
+
+    /**
+     * Finds all non-deleted competitions which are marked as <i>pinned</i>.
+     *
+     * @return a list of non-deleted competitions which are marked as "pinned"
+     */
+    // CAST(id as varchar) is a workaround for https://github.com/spring-projects/spring-data-jpa/issues/1796
+    @Query(
+            value = """
+                    SELECT CAST(c.id as varchar) as id, c.name as name, c.season as season, c.logo_url as logoUrl \
+                    FROM competition c \
+                    WHERE c.pinned = true AND c.deleted = false \
+                    """,
+            nativeQuery = true
+    )
+    List<CompetitionDto> findAllPinned();
 
     /**
      * Finds all competition-specific statistics of players who play in the specified competition.

--- a/competition-service/src/main/java/pl/echelon133/competitionservice/competition/service/CompetitionService.java
+++ b/competition-service/src/main/java/pl/echelon133/competitionservice/competition/service/CompetitionService.java
@@ -64,6 +64,15 @@ public class CompetitionService {
     }
 
     /**
+     * Finds all non-deleted competitions which are marked as <i>pinned</i>.
+     *
+     * @return a list of non-deleted competitions which are marked as "pinned"
+     */
+    public List<CompetitionDto> findPinnedCompetitions() {
+        return competitionRepository.findAllPinned();
+    }
+
+    /**
      * Creates a competition's entry in the database.
      *
      * The values in {@link UpsertCompetitionDto} have to be pre-validated before being used here,
@@ -79,6 +88,7 @@ public class CompetitionService {
                 competitionDto.season(),
                 competitionDto.logoUrl()
         );
+        competition.setPinned(competitionDto.pinned());
 
         List<Group> groups = new ArrayList<>(competitionDto.groups().size());
 

--- a/competition-service/src/test/java/pl/echelon133/competitionservice/competition/TestCompetition.java
+++ b/competition-service/src/test/java/pl/echelon133/competitionservice/competition/TestCompetition.java
@@ -21,6 +21,7 @@ public interface TestCompetition {
         private List<Group> groups = List.of();
         private List<Legend> legend = List.of();
         private boolean deleted = false;
+        private boolean pinned = false;
 
         private CompetitionBuilder() {}
 
@@ -59,8 +60,14 @@ public interface TestCompetition {
             return this;
         }
 
+        public CompetitionBuilder pinned(boolean pinned) {
+            this.pinned = pinned;
+            return this;
+        }
+
         public Competition build() {
             var competition = new Competition(name, season, logoUrl, groups, legend);
+            competition.setPinned(pinned);
             competition.setId(id);
             competition.setDeleted(deleted);
             return competition;

--- a/competition-service/src/test/java/pl/echelon133/competitionservice/competition/TestUpsertCompetitionDto.java
+++ b/competition-service/src/test/java/pl/echelon133/competitionservice/competition/TestUpsertCompetitionDto.java
@@ -22,6 +22,7 @@ public interface TestUpsertCompetitionDto {
         private List<UpsertCompetitionDto.UpsertLegendDto> legend = List.of(
                 TestUpsertLegendDto.builder().build()
         );
+        private boolean pinned;
 
         private UpsertCompetitionDtoBuilder() {}
 
@@ -50,8 +51,13 @@ public interface TestUpsertCompetitionDto {
             return this;
         }
 
+        public UpsertCompetitionDtoBuilder pinned(boolean pinned) {
+            this.pinned = pinned;
+            return this;
+        }
+
         public UpsertCompetitionDto build() {
-            return new UpsertCompetitionDto(name, season, logoUrl, groups, legend);
+            return new UpsertCompetitionDto(name, season, logoUrl, groups, legend, pinned);
         }
     }
 }

--- a/competition-service/src/test/java/pl/echelon133/competitionservice/competition/controller/CompetitionControllerTests.java
+++ b/competition-service/src/test/java/pl/echelon133/competitionservice/competition/controller/CompetitionControllerTests.java
@@ -220,6 +220,26 @@ public class CompetitionControllerTests {
     }
 
     @Test
+    @DisplayName("GET /api/competitions/pinned returns 200")
+    public void getPinnedCompetitions_NoRequestParameters_StatusOk() throws Exception {
+        var expectedName = "Competition 1";
+        var expectedContent = List.of(CompetitionDto.from(UUID.randomUUID(), expectedName, "test2", "test3"));
+
+        // given
+        given(competitionService.findPinnedCompetitions()).willReturn(expectedContent);
+
+        // when
+        mvc.perform(
+                        get("/api/competitions/pinned")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .accept(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.size()", is(1)))
+                .andExpect(jsonPath("$.[0].name", is(expectedName)));
+    }
+
+    @Test
     @DisplayName("POST /api/competitions returns 422 when name is not provided")
     public void createCompetition_NameNotProvided_StatusUnprocessableEntity() throws Exception {
         var contentDto = TestUpsertCompetitionDto.builder().name(null).build();

--- a/competition-service/src/test/java/pl/echelon133/competitionservice/competition/repository/CompetitionRepositoryTests.java
+++ b/competition-service/src/test/java/pl/echelon133/competitionservice/competition/repository/CompetitionRepositoryTests.java
@@ -180,6 +180,33 @@ public class CompetitionRepositoryTests {
     }
 
     @Test
+    @DisplayName("findAllPinned native query only fetches non-deleted competitions which are marked as pinned")
+    public void findAllPinned_MultipleCombinationsOfCompetitions_OnlyFindsPinnedNonDeletedCompetitions() {
+        // competitions which should NOT be returned by the tested query
+        competitionRepository.saveAll(List.of(
+                // 1. deleted, not pinned
+                TestCompetition.builder().deleted(true).build(),
+                // 2. deleted, pinned
+                TestCompetition.builder().deleted(true).pinned(true).build(),
+                // 3. non-deleted, not pinned
+                TestCompetition.builder().build())
+        );
+
+        // the only competition which should be returned by the query
+        // 4. non-deleted, pinned
+        var expectedCompetition = competitionRepository.save(
+                TestCompetition.builder().name("Competition4").pinned(true).build()
+        );
+
+        // when
+        var result = competitionRepository.findAllPinned();
+
+        // then
+        assertEquals(1, result.size());
+        assertEntityAndDtoEqual(expectedCompetition, result.get(0));
+    }
+
+    @Test
     @DisplayName("findPlayerStats native query finds zero player stats when the competition does not exist")
     public void findPlayerStats_CompetitionNotFound_ContentIsEmpty() {
         var competitionId = UUID.randomUUID();


### PR DESCRIPTION
Makes it possible to mark competitions as *pinned*. 

Requests to **POST /api/competitions** can now attach a *pinned* flag in their JSON body.

```JSON
{
  "name": "Champions League",
  "season": "2024/25",
  "logoUrl": "some-url-to-logo",
  "groups": [],
  "legend": [],
  "pinned": true
}
```

All non-deleted competitions which are pinned can be fetched with **GET /api/competitions/pinned** HTTP request.

This feature makes it possible for the API clients to provide quick access to the most important competitions by displaying a list of links to them.